### PR TITLE
use the "enter" key to do the search

### DIFF
--- a/redis-desktop-manager/source/application.cpp
+++ b/redis-desktop-manager/source/application.cpp
@@ -89,6 +89,8 @@ void MainWin::initFilter()
 {
     connect(ui.pbFindFilter, SIGNAL(clicked()), SLOT(OnSetFilter()));
     connect(ui.pbClearFilter, SIGNAL(clicked()), SLOT(OnClearFilter()));
+    connect(ui.leKeySearchPattern, SIGNAL(returnPressed()), ui.pbFindFilter,
+            SIGNAL(clicked()), Qt::UniqueConnection);
 }
 
 void MainWin::initSystemConsole()


### PR DESCRIPTION
Just connect the "returnPress" SIGNAL of the search QLineEdit to the "clicked" SIGNAL of the find Button.

Make the search action more smoothly.
:)
