### PR TITLE
Fixes typo

### DIFF
--- a/src/modules/redisclient/transporters/abstracttransporter.cpp
+++ b/src/modules/redisclient/transporters/abstracttransporter.cpp
@@ -74,7 +74,7 @@ void RedisClient::AbstractTransporter::sendResponse()
             );
     }
 
-    emit logEvent(QString("%1 > [runCommand] %2 -> response recieved").arg(m_connection->config.name).arg(runningCommand.getRawString()));
+    emit logEvent(QString("%1 > [runCommand] %2 -> response received").arg(m_connection->config.name).arg(runningCommand.getRawString()));
 
     m_isCommandRunning = false;
 


### PR DESCRIPTION
Hello,

I came across a small typo (recieved vs. received) in `abstracttransporter.cpp` that I changed.

Thanks for the great tool!
