### PR TITLE
Change ConnectionWindow window style

### DIFF
--- a/src/app/dialogs/connect.cpp
+++ b/src/app/dialogs/connect.cpp
@@ -12,7 +12,7 @@ ConnectionWindow::ConnectionWindow(QWeakPointer<ConnectionsManager> manager, QWi
 {
     ui.setupUi(this);
 
-    this->setWindowFlags(Qt::Tool);        
+    this->setWindowFlags(Qt::Dialog | Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::WindowCloseButtonHint);       
     this->setModal(true);
 
     ui.validationWarning->hide();


### PR DESCRIPTION
Applying Qt::Tool window style to a widget causes all parent windows to inherit some tooltip like behavior, which is causing the main window to be hidden from the alt-tab menu on Windows systems. New window flags should provide a very similar visual style and fix issue #3322 
