### PR TITLE
Fix issue #3306. Added automatic gzip decompression of values. Recomp…

### DIFF
--- a/src/modules/value-editor/compression.cpp
+++ b/src/modules/value-editor/compression.cpp
@@ -1,0 +1,151 @@
+#include "compression.h"
+
+/**
+ * @brief Attempt to detect if the blob is compressed using the standard GZIP algorithm. May return false positives
+ * @param input The buffer to be compressed
+ * @return @c true if the input buffer is compressed.
+ */
+bool ValueEditor::Compression::isCompressed(QByteArray input) 
+{
+	return !input.isEmpty() && input.size() > 2 && (unsigned char)input.at(0) == 0x1f && (unsigned char)input.at(1) == 0x8b;
+}
+
+/**
+ * @brief Compresses the given buffer using the standard GZIP algorithm
+ * @param input The buffer to be compressed
+ * @param output The result of the compression
+ * @param level The compression level to be used (@c 0 = no compression, @c 9 = max, @c -1 = default)
+ * @return @c true if the compression was successful, @c false otherwise
+ */
+bool ValueEditor::Compression::compress(QByteArray input, QByteArray &output, int level)
+{
+    output.clear();
+
+    if(input.length())
+    {
+        int flush = 0;
+
+        z_stream strm;
+        strm.zalloc = Z_NULL;
+        strm.zfree = Z_NULL;
+        strm.opaque = Z_NULL;
+        strm.avail_in = 0;
+        strm.next_in = Z_NULL;
+
+        int ret = deflateInit2(&strm, qMax(-1, qMin(9, level)), Z_DEFLATED, WINDOW_BIT, 8, Z_DEFAULT_STRATEGY);
+
+        if (ret != Z_OK)
+            return false;
+
+        char *input_data = input.data();
+        int input_data_left = input.length();
+
+        do {
+            int chunk_size = qMin(CHUNK_SIZE, input_data_left);
+
+            strm.next_in = (unsigned char*)input_data;
+            strm.avail_in = chunk_size;
+
+            input_data += chunk_size;
+            input_data_left -= chunk_size;
+
+            flush = (input_data_left <= 0 ? Z_FINISH : Z_NO_FLUSH);
+
+            do {
+                char out[CHUNK_SIZE];
+
+                strm.next_out = (unsigned char*)out;
+                strm.avail_out = CHUNK_SIZE;
+
+                ret = deflate(&strm, flush);
+
+                if(ret == Z_STREAM_ERROR)
+                {
+                    deflateEnd(&strm);
+                    return false;
+                }
+
+                int have = (CHUNK_SIZE - strm.avail_out);
+
+                if(have > 0)
+                    output.append((char*)out, have);
+            } while (strm.avail_out == 0);
+        } while (flush != Z_FINISH);
+
+        (void)deflateEnd(&strm);
+
+        return ret == Z_STREAM_END;
+    }
+    return true;
+}
+
+/**
+ * @brief Decompresses the given buffer using the standard GZIP algorithm
+ * @param input The buffer to be decompressed
+ * @param output The result of the decompression
+ * @return @c true if the decompression was successfull, @c false otherwise
+ */
+bool ValueEditor::Compression::decompress(QByteArray input, QByteArray &output)
+{
+    output.clear();
+
+    if(input.length() > 0)
+    {
+        z_stream strm;
+        strm.zalloc = Z_NULL;
+        strm.zfree = Z_NULL;
+        strm.opaque = Z_NULL;
+        strm.avail_in = 0;
+        strm.next_in = Z_NULL;
+
+        int ret = inflateInit2(&strm, WINDOW_BIT);
+
+        if (ret != Z_OK)
+            return false;
+
+        char *input_data = input.data();
+        int input_data_left = input.length();
+
+        do {
+            int chunk_size = qMin(CHUNK_SIZE, input_data_left);
+
+            if(chunk_size <= 0)
+                break;
+
+            strm.next_in = (unsigned char*)input_data;
+            strm.avail_in = chunk_size;
+
+            input_data += chunk_size;
+            input_data_left -= chunk_size;
+
+            do {
+                char out[CHUNK_SIZE];
+
+                strm.next_out = (unsigned char*)out;
+                strm.avail_out = CHUNK_SIZE;
+
+                ret = inflate(&strm, Z_NO_FLUSH);
+
+                switch (ret) {
+                case Z_NEED_DICT:
+                    ret = Z_DATA_ERROR;
+                case Z_DATA_ERROR:
+                case Z_MEM_ERROR:
+                case Z_STREAM_ERROR:
+                    inflateEnd(&strm);
+                    return false;
+                }
+
+                int have = (CHUNK_SIZE - strm.avail_out);
+
+                if(have > 0)
+                    output.append((char*)out, have);
+            } while (strm.avail_out == 0);
+        } while (ret != Z_STREAM_END);
+
+        inflateEnd(&strm);
+
+        return ret == Z_STREAM_END;
+    }
+    return true;
+}

--- a/src/modules/value-editor/compression.h
+++ b/src/modules/value-editor/compression.h
@@ -1,0 +1,23 @@
+#pragma once 
+
+#ifndef COMPRESSOR_H
+#define COMPRESSOR_H
+
+#include <zlib.h>
+#include <QByteArray>
+
+#define WINDOW_BIT 15 + 16
+#define CHUNK_SIZE 32 * 1024
+
+namespace ValueEditor {
+
+class Compression
+{
+public:
+	static bool isCompressed(QByteArray input);
+    static bool compress(QByteArray input, QByteArray &output, int level = -1);
+    static bool decompress(QByteArray input, QByteArray &output);
+};
+
+}
+#endif // COMPRESSOR_H

--- a/src/modules/value-editor/valueviewmodel.h
+++ b/src/modules/value-editor/valueviewmodel.h
@@ -3,6 +3,7 @@
 #include <QSharedPointer>
 #include <QVariantMap>
 #include "keymodel.h"
+#include "compression.h"
 
 namespace ValueEditor {
 
@@ -25,7 +26,7 @@ public:
     Q_INVOKABLE void updateRow(int i, const QVariantMap& row);
     Q_INVOKABLE void deleteRow(int i);
     Q_INVOKABLE QVariantMap getRow(int i, bool relative = false);
-
+    
     // multi row operations
     Q_INVOKABLE void loadRows(int start, int count);
     Q_INVOKABLE bool isMultiRow();
@@ -47,6 +48,7 @@ private:
 protected:
     bool isIndexValid(const QModelIndex &index) const;
     int mapRowIndex(int i);
+    QVariantMap getRowRaw(int row, bool relative = false);
 
 private:
     int m_startFramePosition;

--- a/src/rdm.pro
+++ b/src/rdm.pro
@@ -15,7 +15,7 @@ TEMPLATE = app
     message("Version: 0.8.0.0")
 }
 
-DEFINES += ELPP_QT_LOGGING ELPP_STL_LOGGING
+DEFINES += CORE_LIBRARY ELPP_QT_LOGGING ELPP_STL_LOGGING
 
 SOURCES += \
     $$PWD/main.cpp \
@@ -61,7 +61,7 @@ include($$THIRDPARTYDIR/3rdparty.pri)
 #win32-msvc* {
 win32 {
     CONFIG += c++11
-    LIBS += -lws2_32 -lkernel32 -luser32 -lshell32 -luuid -lole32 -ladvapi32
+    LIBS += -lws2_32 -lkernel32 -luser32 -lshell32 -luuid -lole32 -ladvapi32 -lz
     RC_FILE += $$PWD/resources/rdm.rc
 
     release: DESTDIR = ./../bin/windows/release
@@ -72,6 +72,7 @@ unix:macx { # OSX
     CONFIG += c++11 #release
     #CONFIG -= debug
 
+    LIBS += -lz
     debug {
         CONFIG-=app_bundle
     }
@@ -94,6 +95,7 @@ unix:!macx { # ubuntu & debian
 
     CONFIG += static release
     CONFIG -= debug
+    LIBS += -lz
 
     QMAKE_LFLAGS += -static-libgcc -static-libstdc++
 

--- a/tests/unit_tests/testcases/value-editor/value-editor-tests.pri
+++ b/tests/unit_tests/testcases/value-editor/value-editor-tests.pri
@@ -4,13 +4,8 @@ VALUEEDITOR_SRC_DIR = $$PWD/../../../../src/modules/value-editor/
 HEADERS  += \
     $$PWD/*.h \
     $$PWD/mocks/*.h \
-    $$VALUEEDITOR_SRC_DIR/view.h \
-    $$VALUEEDITOR_SRC_DIR/viewmodel.h \
-    $$VALUEEDITOR_SRC_DIR/valueviewmodel.h \
-    $$VALUEEDITOR_SRC_DIR/keymodel.h \
+    $$VALUEEDITOR_SRC_DIR/*.h \
 
 SOURCES += \
     $$PWD/*.cpp \
-    $$VALUEEDITOR_SRC_DIR/view.cpp \
-    $$VALUEEDITOR_SRC_DIR/viewmodel.cpp \
-    $$VALUEEDITOR_SRC_DIR/valueviewmodel.cpp \
+    $$VALUEEDITOR_SRC_DIR/*.cpp \


### PR DESCRIPTION
…resses user-modified values.

This change adds transparent decompression. When the user changes a value that is from a compressed key, it re-compresses the updated value and saves.

I only have a build environment on Ubuntu so I don't know if the rdm.pro changes for win or mac are correct.
