### PR TITLE
Display the number keys inside each namespace, recursively. (issue #3470)

### DIFF
--- a/src/modules/connections-tree/items/databaseitem.cpp
+++ b/src/modules/connections-tree/items/databaseitem.cpp
@@ -298,7 +298,7 @@ void DatabaseItem::KeysTreeRenderer::renderNamaspacedKey(QSharedPointer<Namespac
 
         if (currItem.isNull()) {
             m_result->push_back(namespaceItem);
-            m_rootNamespaces->insert(namespaceItem->getDisplayName(), namespaceItem);
+            m_rootNamespaces->insert(namespaceItem->getOriginalDisplayName(), namespaceItem);
         }
         else currItem->append(namespaceItem);
     }

--- a/src/modules/connections-tree/items/databaseitem.cpp
+++ b/src/modules/connections-tree/items/databaseitem.cpp
@@ -298,7 +298,7 @@ void DatabaseItem::KeysTreeRenderer::renderNamaspacedKey(QSharedPointer<Namespac
 
         if (currItem.isNull()) {
             m_result->push_back(namespaceItem);
-            m_rootNamespaces->insert(namespaceItem->getOriginalDisplayName(), namespaceItem);
+            m_rootNamespaces->insert(namespaceItem->getName(), namespaceItem);
         }
         else currItem->append(namespaceItem);
     }

--- a/src/modules/connections-tree/items/databaseitem.cpp
+++ b/src/modules/connections-tree/items/databaseitem.cpp
@@ -53,7 +53,7 @@ QList<QSharedPointer<TreeItem> > DatabaseItem::getAllChilds() const
     return *m_keys;
 }
 
-uint DatabaseItem::childCount() const
+uint DatabaseItem::childCount(bool recursive) const
 {
     return m_keys->size();
 }

--- a/src/modules/connections-tree/items/databaseitem.h
+++ b/src/modules/connections-tree/items/databaseitem.h
@@ -21,7 +21,7 @@ public:
     QString getDisplayName() const override;
     QIcon getIcon() const override;
     QList<QSharedPointer<TreeItem>> getAllChilds() const override;
-    uint childCount() const override;
+    uint childCount(bool recursive = false) const override;
     QSharedPointer<TreeItem> child(uint row) const override;
     QWeakPointer<TreeItem> parent() const override;
 

--- a/src/modules/connections-tree/items/keyitem.cpp
+++ b/src/modules/connections-tree/items/keyitem.cpp
@@ -31,7 +31,12 @@ QList<QSharedPointer<TreeItem>> KeyItem::getAllChilds() const
     return QList<QSharedPointer<TreeItem>>();
 }
 
-uint KeyItem::childCount() const
+bool KeyItem::supportChildItems() const
+{
+    return false;
+}
+
+uint KeyItem::childCount(bool recursive) const
 {
     return (uint)0;
 }

--- a/src/modules/connections-tree/items/keyitem.h
+++ b/src/modules/connections-tree/items/keyitem.h
@@ -14,7 +14,8 @@ namespace ConnectionsTree {
         QString getDisplayName() const override;
         QIcon getIcon() const override;
         QList<QSharedPointer<TreeItem>> getAllChilds() const override;
-        uint childCount() const override;
+        bool supportChildItems() const override;
+        uint childCount(bool recursive = false) const override;
         QSharedPointer<TreeItem> child(uint row) const override;
         QWeakPointer<TreeItem> parent() const override;
 

--- a/src/modules/connections-tree/items/namespaceitem.cpp
+++ b/src/modules/connections-tree/items/namespaceitem.cpp
@@ -17,7 +17,7 @@ NamespaceItem::NamespaceItem(const QString &fullPath,
 
 QString NamespaceItem::getDisplayName() const
 {    
-    return QString("%1 (%2)").arg(m_displayName).arg(descendantCount());
+    return QString("%1 (%2)").arg(m_displayName).arg(childCount(true));
 }
 
 QString NamespaceItem::getName() const
@@ -35,19 +35,17 @@ QList<QSharedPointer<TreeItem> > NamespaceItem::getAllChilds() const
     return m_childItems;
 }
 
-uint NamespaceItem::childCount() const
+uint NamespaceItem::childCount(bool recursive) const
 {
-    return m_childItems.size();
-}
+    if (!recursive)
+        return m_childItems.size();
 
-uint NamespaceItem::descendantCount() const
-{
     uint count = 0;
     for (auto item : m_childItems) {
-        if (typeid(NamespaceItem)==typeid(*item)) {
-            count += item.staticCast<NamespaceItem>()->descendantCount();
+        if (item->supportChildItems()) {
+            count += item->childCount(true);
         } else {
-            count++;
+            count += 1;
         }
     }
     return count;

--- a/src/modules/connections-tree/items/namespaceitem.cpp
+++ b/src/modules/connections-tree/items/namespaceitem.cpp
@@ -17,6 +17,11 @@ NamespaceItem::NamespaceItem(const QString &fullPath,
 
 QString NamespaceItem::getDisplayName() const
 {    
+    return QString("%1 (%2)").arg(m_displayName).arg(descendantCount());
+}
+
+QString NamespaceItem::getOriginalDisplayName() const
+{
     return m_displayName;
 }
 
@@ -33,6 +38,19 @@ QList<QSharedPointer<TreeItem> > NamespaceItem::getAllChilds() const
 uint NamespaceItem::childCount() const
 {
     return m_childItems.size();
+}
+
+uint NamespaceItem::descendantCount() const
+{
+    uint count = 0;
+    for (auto item : m_childItems) {
+        if (typeid(NamespaceItem)==typeid(*item)) {
+            count += item.staticCast<NamespaceItem>()->descendantCount();
+        } else {
+            count++;
+        }
+    }
+    return count;
 }
 
 QSharedPointer<TreeItem> NamespaceItem::child(uint row) const
@@ -71,7 +89,7 @@ bool NamespaceItem::isEnabled() const
 void NamespaceItem::append(QSharedPointer<TreeItem> item)
 {
     if (typeid(NamespaceItem)==typeid(*item)) {
-        m_childNamespaces[item->getDisplayName()] = qSharedPointerCast<NamespaceItem>(item);
+        m_childNamespaces[item.staticCast<NamespaceItem>()->getOriginalDisplayName()] = qSharedPointerCast<NamespaceItem>(item);
     }
     m_childItems.append(item);
 }

--- a/src/modules/connections-tree/items/namespaceitem.cpp
+++ b/src/modules/connections-tree/items/namespaceitem.cpp
@@ -20,7 +20,7 @@ QString NamespaceItem::getDisplayName() const
     return QString("%1 (%2)").arg(m_displayName).arg(descendantCount());
 }
 
-QString NamespaceItem::getOriginalDisplayName() const
+QString NamespaceItem::getName() const
 {
     return m_displayName;
 }
@@ -89,7 +89,7 @@ bool NamespaceItem::isEnabled() const
 void NamespaceItem::append(QSharedPointer<TreeItem> item)
 {
     if (typeid(NamespaceItem)==typeid(*item)) {
-        m_childNamespaces[item.staticCast<NamespaceItem>()->getOriginalDisplayName()] = qSharedPointerCast<NamespaceItem>(item);
+        m_childNamespaces[item.staticCast<NamespaceItem>()->getName()] = qSharedPointerCast<NamespaceItem>(item);
     }
     m_childItems.append(item);
 }

--- a/src/modules/connections-tree/items/namespaceitem.h
+++ b/src/modules/connections-tree/items/namespaceitem.h
@@ -13,8 +13,7 @@ namespace ConnectionsTree {
         QString getName() const;
         QIcon getIcon() const override;
         QList<QSharedPointer<TreeItem>> getAllChilds() const override;
-        uint childCount() const override;
-        uint descendantCount() const;
+        uint childCount(bool recursive = false) const override;
         QSharedPointer<TreeItem> child(uint row) const override;
         QWeakPointer<TreeItem> parent() const override;
 

--- a/src/modules/connections-tree/items/namespaceitem.h
+++ b/src/modules/connections-tree/items/namespaceitem.h
@@ -10,7 +10,7 @@ namespace ConnectionsTree {
         NamespaceItem(const QString& fullPath,  QSharedPointer<Operations> operations, QWeakPointer<TreeItem> parent);
 
         QString getDisplayName() const override;
-        QString getOriginalDisplayName() const;
+        QString getName() const;
         QIcon getIcon() const override;
         QList<QSharedPointer<TreeItem>> getAllChilds() const override;
         uint childCount() const override;

--- a/src/modules/connections-tree/items/namespaceitem.h
+++ b/src/modules/connections-tree/items/namespaceitem.h
@@ -10,9 +10,11 @@ namespace ConnectionsTree {
         NamespaceItem(const QString& fullPath,  QSharedPointer<Operations> operations, QWeakPointer<TreeItem> parent);
 
         QString getDisplayName() const override;
+        QString getOriginalDisplayName() const;
         QIcon getIcon() const override;
         QList<QSharedPointer<TreeItem>> getAllChilds() const override;
         uint childCount() const override;
+        uint descendantCount() const;
         QSharedPointer<TreeItem> child(uint row) const override;
         QWeakPointer<TreeItem> parent() const override;
 

--- a/src/modules/connections-tree/items/serveritem.cpp
+++ b/src/modules/connections-tree/items/serveritem.cpp
@@ -59,7 +59,7 @@ QList<QSharedPointer<TreeItem> > ServerItem::getAllChilds() const
     return m_databases;
 }
 
-uint ServerItem::childCount() const
+uint ServerItem::childCount(bool recursive) const
 {
     return static_cast<uint>(m_databases.size());
 }

--- a/src/modules/connections-tree/items/serveritem.h
+++ b/src/modules/connections-tree/items/serveritem.h
@@ -19,7 +19,7 @@ namespace ConnectionsTree {
         QString getDisplayName() const override;
         QIcon getIcon() const override;
         QList<QSharedPointer<TreeItem>> getAllChilds() const override;
-        uint childCount() const override;
+        uint childCount(bool recursive = false) const override;
         QSharedPointer<TreeItem> child(uint row) const override;
         QWeakPointer<TreeItem> parent() const override;
 

--- a/src/modules/connections-tree/items/treeitem.h
+++ b/src/modules/connections-tree/items/treeitem.h
@@ -25,9 +25,11 @@ public:
     virtual QString getDisplayName() const = 0;
     virtual QIcon getIcon() const = 0;
     virtual QList<QSharedPointer<TreeItem>> getAllChilds() const = 0;
-    virtual uint childCount() const = 0;
+    virtual uint childCount(bool recursive = false) const = 0;
     virtual QSharedPointer<TreeItem> child(uint row) const = 0;
     virtual QWeakPointer<TreeItem> parent() const = 0;
+
+    virtual bool supportChildItems() const { return true; }
 
     virtual int row() const
     {


### PR DESCRIPTION
For each namespace, this shows how many keys are inside it, which I find very useful to have a _very rough_ idea of where my Redis memory usage is going, and also a rough idea of what my app is doing with Redis (how many objects of each type are getting cached, things like that).

The implementation is a bit hacky, because `NamespaceItem::getDisplayName` is being used both for actual display, and as the key in hash tables that list child namespaces. To get around this, I added a `getOriginalDisplayName` method to use for the hash key. I admit the name could've probably been a bit better, but I don't know the codebase well enough to pick a better one (i'd be happy to rename to whatever you'd like to see).

This also required a couple of casts, hope those are OK.

If you think this is a good idea to incorporate, but don't like how it's implemented, i'll be happy to improve it / change it. I'd love to see this on the official app.

Thanks!
Daniel
