### PR TITLE
fix bug: renameKey, removeKey and setTTL only affects the 1st tab.

### DIFF
--- a/src/resources/qml/ValueTabs.qml
+++ b/src/resources/qml/ValueTabs.qml
@@ -123,7 +123,7 @@ Repeater {
                                     return open()
                                 }
 
-                                viewModel.renameKey(keyTab.keyIndex, newKeyName.text)
+                                viewModel.renameKey(keyTab.tabIndex, newKeyName.text)
                             }
 
                             visible: false
@@ -149,7 +149,7 @@ Repeater {
                             text: "Do you really want to delete this key?"
                             onYes: {
                                 console.log("remove key")
-                                viewModel.removeKey(keyTab.keyIndex)
+                                viewModel.removeKey(keyTab.tabIndex)
                             }
                             visible: false
                             modality: Qt.ApplicationModal
@@ -195,7 +195,7 @@ Repeater {
                                     return open()
                                 }
 
-                                viewModel.setTTL(keyTab.keyIndex, newTTL.text)
+                                viewModel.setTTL(keyTab.tabIndex, newTTL.text)
                             }
 
                             visible: false


### PR DESCRIPTION
If multiple tabs are activated on the right panel, the renameKey,
removeKey and setTTL only affects the key of the 1st tab.
