### PR TITLE
fix issue #3623: Renaming key to one that exists

### DIFF
--- a/3rdparty/3rdparty.pri
+++ b/3rdparty/3rdparty.pri
@@ -44,7 +44,7 @@ win32* {
         # Workaround for mingw
         QMAKE_LFLAGS_RELEASE=
     } else {
-        INCLUDEPATH += $$PWD/qredisclient/3rdparty/windows/rmt_zlib.1.2.8.6/build/native/include
+        INCLUDEPATH += $$PWD/qredisclient/3rdparty/windows/rmt_zlib.1.2.8.5/build/native/include
     }
 
     HEADERS += $$BREAKPADDIR/common/windows/string_utils-inl.h

--- a/src/resources/qml/value-editor.qml
+++ b/src/resources/qml/value-editor.qml
@@ -122,7 +122,7 @@ Rectangle {
         target: viewModel
         onKeyError: {
             if (index != -1)
-                tabs.currentIndex = index + 1
+                tabs.currentIndex = index
             errorNotification.text = error
             errorNotification.open()
         }


### PR DESCRIPTION
The tab index is set to the next tab if error occurs.
All tabs are missing if the focus is on the last tab, because
tabs.currentIndex is set to a tab that does not exist.
If you activate a tab other than the last one, when error occurs, the
next tab is activated instead of the current one.
