### PR TITLE
Add CentOS (7) checks and feedback in configure script

### DIFF
--- a/build/common_functions
+++ b/build/common_functions
@@ -184,34 +184,3 @@ function GetDistro {
     fi
     export DISTRO
 }
-
-function CompareVersionStrings () {
-    if [[ $1 == $2 ]]
-    then
-        return 0
-    fi
-    local IFS=.
-    local i ver1=($1) ver2=($2)
-    # fill empty fields in ver1 with zeros
-    for ((i=${#ver1[@]}; i<${#ver2[@]}; i++))
-    do
-        ver1[i]=0
-    done
-    for ((i=0; i<${#ver1[@]}; i++))
-    do
-        if [[ -z ${ver2[i]} ]]
-        then
-            # fill empty fields in ver2 with zeros
-            ver2[i]=0
-        fi
-        if ((10#${ver1[i]} > 10#${ver2[i]}))
-        then
-            return 1
-        fi
-        if ((10#${ver1[i]} < 10#${ver2[i]}))
-        then
-            return 2
-        fi
-    done
-    return 0
-}

--- a/build/common_functions
+++ b/build/common_functions
@@ -184,3 +184,34 @@ function GetDistro {
     fi
     export DISTRO
 }
+
+function CompareVersionStrings () {
+    if [[ $1 == $2 ]]
+    then
+        return 0
+    fi
+    local IFS=.
+    local i ver1=($1) ver2=($2)
+    # fill empty fields in ver1 with zeros
+    for ((i=${#ver1[@]}; i<${#ver2[@]}; i++))
+    do
+        ver1[i]=0
+    done
+    for ((i=0; i<${#ver1[@]}; i++))
+    do
+        if [[ -z ${ver2[i]} ]]
+        then
+            # fill empty fields in ver2 with zeros
+            ver2[i]=0
+        fi
+        if ((10#${ver1[i]} > 10#${ver2[i]}))
+        then
+            return 1
+        fi
+        if ((10#${ver1[i]} < 10#${ver2[i]}))
+        then
+            return 2
+        fi
+    done
+    return 0
+}

--- a/src/configure
+++ b/src/configure
@@ -11,6 +11,8 @@ DIR=$(dirname "$(readlink -f "$0")") && RDM_DIR=$DIR/../
 . $RDM_DIR/build/common_functions
 
 GetOSVersion
+CompareVersionStrings "$os_RELEASE" "7"
+versionCheck=$?
 
 RDM_QT_VERSION=${RDM_QT_VERSION:-542}
 
@@ -21,7 +23,7 @@ if [ "$1" == "breakpad" ]; then
 fi
 
 if [ "$os_VENDOR" == "Ubuntu" ]; then
-    ubuntu_ver=${os_RELEASE:0:2}	
+    ubuntu_ver=${os_RELEASE:0:2}
     print_title "Build RDM on Ubuntu: $ubuntu_ver"
 
     if [ "$ubuntu_ver" == "12" ]; then
@@ -62,7 +64,7 @@ if [ "$os_VENDOR" == "Ubuntu" ]; then
             dh-make diffutils patch gnupg fakeroot lintian pbuilder git python perl -y
         sudo apt-get build-dep qt5-default -y
     fi
-        
+
     print_title "Check deps"
     sudo apt-get install automake libtool libssl-dev \
         libssh2-1-dev g++ libgl1-mesa-dev -y
@@ -70,14 +72,20 @@ if [ "$os_VENDOR" == "Ubuntu" ]; then
     build_breakpad
 
     print_title "Run: source /opt/qt${RDM_QT_VERSION:0:2}/bin/qt${RDM_QT_VERSION:0:2}-env.sh && qmake && make "
-elif [  "$os_VENDOR" == "Fedora" ]; then
-    print_title "Build RDM on Fedora: $os_RELEASE"
+elif [  "$os_VENDOR" == "Fedora" ] || [[ "$os_VENDOR" == "CentOS" && ${versionCheck} == 1 ]]; then
+    print_title "Build RDM on $os_VENDOR: $os_RELEASE"
 
     print_title "Check deps"
     sudo yum install libssh2 libssh2-devel qt5-qtbase qt5-qtsvg-devel \
         qt5-qtdeclarative-devel qt5-qtgraphicaleffects qt5-qtquickcontrols  \
         qt5-qttools gcc gcc-c++ libstdc++-static git rsync \
         redhat-rpm-config -y
+
+    if [[ $? == 1 && "$os_VENDOR" == "CentOS" ]]; then
+      # Some of the deps might need to come from Epel, so output a nice message
+      print_title "Not all dependencies were found. Ensure you have the epel repo installed and enabled."
+      exit
+    fi
 
     build_breakpad
 

--- a/src/configure
+++ b/src/configure
@@ -11,8 +11,6 @@ DIR=$(dirname "$(readlink -f "$0")") && RDM_DIR=$DIR/../
 . $RDM_DIR/build/common_functions
 
 GetOSVersion
-CompareVersionStrings "$os_RELEASE" "7"
-versionCheck=$?
 
 RDM_QT_VERSION=${RDM_QT_VERSION:-542}
 
@@ -72,7 +70,7 @@ if [ "$os_VENDOR" == "Ubuntu" ]; then
     build_breakpad
 
     print_title "Run: source /opt/qt${RDM_QT_VERSION:0:2}/bin/qt${RDM_QT_VERSION:0:2}-env.sh && qmake && make "
-elif [  "$os_VENDOR" == "Fedora" ] || [[ "$os_VENDOR" == "CentOS" && ${versionCheck} == 1 ]]; then
+elif [  "$os_VENDOR" == "Fedora" ] || [[ "$os_VENDOR" == "CentOS" && "$os_RELEASE" -ge "7" ]]; then
     print_title "Build RDM on $os_VENDOR: $os_RELEASE"
 
     print_title "Check deps"


### PR DESCRIPTION
Purpose:

I speculatively changed the configure script to check for "CentOS" instead of "Fedora", after considering that their base packages share some RHEL inheritance, and the build just worked. Having found though that some dependencies come from the non-standard epel repo, I have also added some checks to ensure that the dep installation from yum succeeds entirely before continuing, while giving some feedback if not.

Commit messages:
- Add CompareVersionStrings function in common_function file, which can be used to compare absolute version numbers (integers, perhaps) with version strings
- Add CentOS (7) vendor check in with Fedora build commands, including some feedback if yum fails on any of the dependencies
