### PR TITLE
In order to run this qt-5-6-2 is needed on Ubuntu 16.04

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -12,7 +12,7 @@ DIR=$(dirname "$(readlink -f "$0")") && RDM_DIR=$DIR/../
 
 GetOSVersion
 
-RDM_QT_VERSION=${RDM_QT_VERSION:-561}
+RDM_QT_VERSION=${RDM_QT_VERSION:-562}
 
 if [ "$1" == "breakpad" ]; then
     print_title "Build only Breakpad"


### PR DESCRIPTION
https://launchpad.net/~beineri/+archive/ubuntu/opt-qt562-xenial does not have 561 only 562, so the problem here is I do not know if this will break the installation process on other platforms.