### PR TITLE
Fixed simple bug with rdm-native-value-formatters.

### DIFF
--- a/src/modules/value-editor/formattersmanager.cpp
+++ b/src/modules/value-editor/formattersmanager.cpp
@@ -174,7 +174,8 @@ void ValueEditor::FormattersManager::decode(const QString &formatterName, const 
     }
 
     if (jsCallback.isCallable()) {
-        jsCallback.call(QJSValueList { outputObj["output"].toString(),
+        jsCallback.call(QJSValueList { outputObj["error"].toString(),
+                                       outputObj["output"].toString(),
                                        outputObj["read-only"].toBool(),
                                        outputObj["format"].toString() });
     }


### PR DESCRIPTION
The js callback was expecting 4 parameters (the first being error) while it was being called with 3.

This was a simple 1-liner. @uglide please accept when you get the chance.

Thanks!