### PR TITLE
Fix issue 4056

### DIFF
--- a/src/qml/value-editor/editors/HashItemEditor.qml
+++ b/src/qml/value-editor/editors/HashItemEditor.qml
@@ -41,8 +41,15 @@ AbstractEditor {
 
     function validateValue(callback) {
         keyText.validate(function (keyTextValid) {
-            textArea.validate(function (keyTextValid) {
-                return callback(keyTextValid);
+            textArea.loadRawValue(function(error, raw) {
+                if(!error && (qmlUtils.binaryStringLength(raw) > 0)) {
+                    textArea.validate(function (keyTextValid) {
+                        return callback(keyTextValid);
+                    });
+                }
+                else {
+                    return callback(keyTextValid);
+                }
             });
         });
     }

--- a/src/qml/value-editor/editors/HashItemEditor.qml
+++ b/src/qml/value-editor/editors/HashItemEditor.qml
@@ -41,7 +41,9 @@ AbstractEditor {
 
     function validateValue(callback) {
         keyText.validate(function (keyTextValid) {
-            return callback(keyTextValid);
+            textArea.validate(function (keyTextValid) {
+                return callback(keyTextValid);
+            });
         });
     }
 


### PR DESCRIPTION
Adding and modifying a hash's value didn't work from the GUI as the validation was only done on the key and not on the value. The validation sets the value of the fields which was always empty for the value field as the validation was not done for the value field. This PR fixes [issue#4056](https://github.com/uglide/RedisDesktopManager/issues/4056).