### PR TITLE
Improve databases discovery

### DIFF
--- a/src/app/models/connectionconf.cpp
+++ b/src/app/models/connectionconf.cpp
@@ -41,6 +41,16 @@ void ServerConfig::setLuaKeysLoading(bool value)
     return setParam<bool>("lua_keys_loading", value);
 }
 
+uint ServerConfig::databaseScanLimit() const
+{
+    return param<uint>("db_scan_limit", DEFAULT_DB_SCAN_LIMIT);
+}
+
+void ServerConfig::setDatabaseScanLimit(uint limit)
+{
+    setParam<uint>("db_scan_limit", limit);
+}
+
 bool ServerConfig::useSshTunnel() const
 {
     return RedisClient::ConnectionConfig::useSshTunnel();

--- a/src/app/models/connectionconf.h
+++ b/src/app/models/connectionconf.h
@@ -31,11 +31,13 @@ class ServerConfig : public RedisClient::ConnectionConfig
     Q_PROPERTY(uint executeTimeout READ executeTimeout WRITE setExecutionTimeout)
     Q_PROPERTY(uint connectionTimeout READ connectionTimeout WRITE setConnectionTimeout)
     Q_PROPERTY(bool luaKeysLoading READ luaKeysLoading WRITE setLuaKeysLoading)
+    Q_PROPERTY(uint databaseScanLimit READ databaseScanLimit WRITE setDatabaseScanLimit)
 
 public:
     static const char DEFAULT_NAMESPACE_SEPARATOR = ':';
     static const char DEFAULT_KEYS_GLOB_PATTERN = '*';
     static const bool DEFAULT_LUA_KEYS_LOADING = false;
+    static const uint DEFAULT_DB_SCAN_LIMIT = 20;
 
 public:
     ServerConfig(const QString & host = "127.0.0.1", const QString & auth = "",
@@ -51,6 +53,9 @@ public:
 
     bool luaKeysLoading() const;
     void setLuaKeysLoading(bool);
+
+    uint databaseScanLimit() const;
+    void setDatabaseScanLimit(uint limit);
 
     Q_INVOKABLE bool useSshTunnel() const;
 };

--- a/src/app/models/treeoperations.h
+++ b/src/app/models/treeoperations.h
@@ -52,4 +52,5 @@ public:
 private:
      QSharedPointer<RedisClient::Connection> m_connection;
      ConnectionsManager& m_manager;
+     uint m_dbCount;
 };

--- a/src/qml/ConnectionSettignsDialog.qml
+++ b/src/qml/ConnectionSettignsDialog.qml
@@ -419,6 +419,19 @@ Dialog {
                             maximumValue: 100000
                             value: root.settings ? (root.settings.connectionTimeout / 1000.0) : 0
                             onValueChanged: root.settings.connectionTimeout = value * 1000
+                        }                        
+
+                        Label { text: qsTr("Databases discovery limit:") }
+
+                        SpinBox {
+                            id: dbScanLimit
+                            Layout.fillWidth: true
+                            minimumValue: 1
+                            maximumValue: 100000
+                            value: {
+                                return root.settings ? root.settings.databaseScanLimit : 1
+                            }
+                            onValueChanged: root.settings.databaseScanLimit = value
                         }
 
                         Label { text: qsTr("Use server-side optimized keys loading (experimental):")}

--- a/tests/unit_tests/testcases/app/test_treeoperations.cpp
+++ b/tests/unit_tests/testcases/app/test_treeoperations.cpp
@@ -24,21 +24,23 @@ void TestTreeOperations::testGetDatabases()
 {
     //given
     ConnectionsManager manager{QString()};
+    QString infoResp = getBulkStringReply(
+        "# CPU\n"
+        "used_cpu_sys:17.89\n"
+        "used_cpu_user:24.70\n"
+        "used_cpu_sys_children:0.06\n"
+        "used_cpu_user_children:0.33\n\n"
+        "# Keyspace\n"
+        "db0:keys=3495,expires=0,avg_ttl=0\n"
+        "db9:keys=1,expires=0,avg_ttl=0\n"
+    );
+
     QStringList expectedResponses{
-        getBulkStringReply(
-            "# CPU\n"
-            "used_cpu_sys:17.89\n"
-            "used_cpu_user:24.70\n"
-            "used_cpu_sys_children:0.06\n"
-            "used_cpu_user_children:0.33\n\n"
-            "# Keyspace\n"
-            "db0:keys=3495,expires=0,avg_ttl=0\n"
-            "db999:keys=1,expires=0,avg_ttl=0\n"
-        ),
+        infoResp, infoResp,
         "+OK\r\n", "+OK\r\n", "+OK\r\n", "-ERROR\r\n"
     };
     auto connection = getFakeConnection();
-    connection->setFakeResponses(expectedResponses);
+    connection->setFakeResponses(expectedResponses);    
     bool callbackCalled = false;
     RedisClient::DatabaseList result;
 
@@ -54,8 +56,8 @@ void TestTreeOperations::testGetDatabases()
     //then
     wait(5);
     QCOMPARE(callbackCalled, true);
-    QCOMPARE(connection->runCommandCalled, 4u);
-    QCOMPARE(result.size(), 1003);
+    QCOMPARE(connection->runCommandCalled, 5u);
+    QCOMPARE(result.size(), 13);
 }
 
 void TestTreeOperations::testLoadNamespaceItems()


### PR DESCRIPTION
- Fix #4031: Number of keys in DB not updating after flush
- Fix #3720: Add support set the max db scan count when
  first connect the redis server (default is 20)