### PR TITLE
Add support for Linux Mint (19)

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -55,6 +55,8 @@ if [ "$os_VENDOR" == "Ubuntu" ] || [ "$os_VENDOR" == "LinuxMint" ] || [ "$os_VEN
             ubuntu_ver="14"
         elif [ "$ubuntu_ver" == "18" ]; then
             ubuntu_ver="16"
+        elif [ "$ubuntu_ver" == "19" ]; then
+            ubuntu_ver="18"
         else
             echo "RedisDesktopManager only supports linux mint >=17."
             exit 1


### PR DESCRIPTION
`configure` script should understand, that Linux Mint 19 Tara based on Ubuntu 18.04 LTS