### PR TITLE
Use proper name for GitHub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
 
 ## IMPORTANT: HOW TO ADD ISSUES
 
-* Github issues **SHOULD ONLY BE USED to report bugs**, and for DETAILED feature
+* GitHub issues **SHOULD ONLY BE USED to report bugs**, and for DETAILED feature
   requests. Everything else belongs to the [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/uglide/RedisDesktopManager)
 
   **PLEASE DO NOT POST GENERAL QUESTIONS** that are not about bugs or suspected
-  bugs in the Github issues system. We'll be very happy to help you and provide
+  bugs in the GitHub issues system. We'll be very happy to help you and provide
   all the support in the [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/uglide/RedisDesktopManager) 
 
 ### Bug report template:

--- a/src/qml/AppToolBar.qml
+++ b/src/qml/AppToolBar.qml
@@ -87,8 +87,8 @@ ToolBar {
 
         ToolButton {
             iconSource: "qrc:/images/github.svg"
-            text: qsTranslate("RDM","Star on Github!")
-            tooltip: qsTranslate("RDM","Star on Github!")
+            text: qsTranslate("RDM","Star on GitHub!")
+            tooltip: qsTranslate("RDM","Star on GitHub!")
             onClicked: Qt.openUrlExternally("https://github.com/uglide/RedisDesktopManager")
         }
 

--- a/src/resources/translations/rdm.ts
+++ b/src/resources/translations/rdm.ts
@@ -474,7 +474,7 @@
     <message>
         <location filename="../../qml/AppToolBar.qml" line="90"/>
         <location filename="../../qml/AppToolBar.qml" line="91"/>
-        <source>Star on Github!</source>
+        <source>Star on GitHub!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/resources/translations/rdm_ru_RU.ts
+++ b/src/resources/translations/rdm_ru_RU.ts
@@ -478,7 +478,7 @@
     <message>
         <location filename="../../qml/AppToolBar.qml" line="90"/>
         <location filename="../../qml/AppToolBar.qml" line="91"/>
-        <source>Star on Github!</source>
+        <source>Star on GitHub!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/resources/translations/rdm_zh_CN.ts
+++ b/src/resources/translations/rdm_zh_CN.ts
@@ -476,8 +476,8 @@
     <message>
         <location filename="../../qml/AppToolBar.qml" line="90"/>
         <location filename="../../qml/AppToolBar.qml" line="91"/>
-        <source>Star on Github!</source>
-        <translation>给我们的Github加个星星吧！</translation>
+        <source>Star on GitHub!</source>
+        <translation>给我们的GitHub加个星星吧！</translation>
     </message>
     <message>
         <location filename="../../qml/AppToolBar.qml" line="99"/>

--- a/src/resources/translations/rdm_zh_TW.ts
+++ b/src/resources/translations/rdm_zh_TW.ts
@@ -477,8 +477,8 @@
     <message>
         <location filename="../../qml/AppToolBar.qml" line="90"/>
         <location filename="../../qml/AppToolBar.qml" line="91"/>
-        <source>Star on Github!</source>
-        <translation>Star on Github!</translation>
+        <source>Star on GitHub!</source>
+        <translation>Star on GitHub!</translation>
     </message>
     <message>
         <location filename="../../qml/AppToolBar.qml" line="99"/>


### PR DESCRIPTION
GitHub has a capital H - in several places in the code and documentation, it is referenced as `Github`. 

It's also written improperly on the sales website, but that isn't part of the repo :) 
![screen shot 2018-12-04 at 8 42 24 am](https://user-images.githubusercontent.com/385724/49445715-8d2a7c80-f7a0-11e8-9b54-6ad5515aa1f3.png)
And
![screen shot 2018-12-04 at 8 42 27 am](https://user-images.githubusercontent.com/385724/49445716-8d2a7c80-f7a0-11e8-98fc-e9b30533d6cb.png)

