### PR TITLE
fix #4382 (applying filters on reloading namespaces)

### DIFF
--- a/src/modules/connections-tree/items/abstractnamespaceitem.cpp
+++ b/src/modules/connections-tree/items/abstractnamespaceitem.cpp
@@ -28,6 +28,16 @@ QSharedPointer<TreeItem> AbstractNamespaceItem::child(uint row) const {
   return QSharedPointer<TreeItem>();
 }
 
+QRegExp AbstractNamespaceItem::getFilter() const {
+  QSharedPointer<AbstractNamespaceItem> parentItem = qSharedPointerDynamicCast<AbstractNamespaceItem>(m_parent);
+
+  if ((!m_filter.isEmpty() && m_filter.pattern().compare(m_operations->defaultFilter()) != 0) || parentItem == 0)  {
+    return m_filter;
+  }
+
+  return parentItem->getFilter();
+}
+
 QWeakPointer<TreeItem> AbstractNamespaceItem::parent() const {
   return m_parent;
 }

--- a/src/modules/connections-tree/items/abstractnamespaceitem.h
+++ b/src/modules/connections-tree/items/abstractnamespaceitem.h
@@ -28,6 +28,8 @@ class AbstractNamespaceItem : public TreeItem {
 
   QWeakPointer<TreeItem> parent() const override;
 
+  QRegExp getFilter() const;
+
   virtual void append(QSharedPointer<TreeItem> item) {
     m_childItems.append(item);
   }

--- a/src/modules/connections-tree/items/namespaceitem.cpp
+++ b/src/modules/connections-tree/items/namespaceitem.cpp
@@ -65,9 +65,10 @@ void NamespaceItem::setRemoved() {
 }
 
 void NamespaceItem::load() {
-  QString nsFilter = QString("%1%2*")
-                         .arg(QString::fromUtf8(m_fullPath))
-                         .arg(m_operations->getNamespaceSeparator());
+  QString nsFilter = QString("%1%2%3")
+                       .arg(QString::fromUtf8(m_fullPath))
+                       .arg(m_operations->getNamespaceSeparator())
+                       .arg(getFilter().pattern());
 
   m_operations->loadNamespaceItems(
       qSharedPointerDynamicCast<AbstractNamespaceItem>(getSelf()), nsFilter,


### PR DESCRIPTION
fix #4382
I'm not sure if it's good solution (because of using dynamic cast and recursion) but it seems, it works :)