### PR TITLE
Update install.md

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -79,7 +79,7 @@ sudo mv qt.conf qt.backup
 
 1. Install Visual Studio 2015 Community with Updates
 
-2. Install [Qt 5.9](https://www.qt.io/download)
+2. Install [Qt 5.9.6](https://www.qt.io/download)
 
 3. Go to `3rdparty/qredisclient/3rdparty/hiredis` and apply patch to fix compilation on Windows:
 `git apply ../hiredis-win.patch`


### PR DESCRIPTION
For building on Windows, If you try with the latest 5.9.X (5.9.7), build fails. The 4th step states that Qt 5.9.6 should be used, so maybe is a good idea to specify that version on the step 2 too.