### PR TITLE
Fix build failure on python3.8

### DIFF
--- a/3rdparty/pyotherside.pri
+++ b/3rdparty/pyotherside.pri
@@ -23,7 +23,7 @@ win32* {
     } else {
       PYTHON_CONFIG = python3-config
 
-      QMAKE_LIBS += $$system($$PYTHON_CONFIG --ldflags --libs)
+      QMAKE_LIBS += $$system($$PYTHON_CONFIG --ldflags --libs --embed)
       QMAKE_CXXFLAGS += $$system($$PYTHON_CONFIG --includes)
       DEFINES *= HAVE_DLADDR
     }


### PR DESCRIPTION
Compile error if missing `--embed`
like this.
![](https://i.loli.net/2020/05/24/KHaEV9CAWzBLRr2.png)