### PR TITLE
Improve UX for TreeView

### DIFF
--- a/src/modules/connections-tree/items/abstractnamespaceitem.cpp
+++ b/src/modules/connections-tree/items/abstractnamespaceitem.cpp
@@ -42,16 +42,32 @@ QWeakPointer<TreeItem> AbstractNamespaceItem::parent() const {
   return m_parent;
 }
 
+bool compareNamespaces(QSharedPointer<TreeItem> first,
+                       QSharedPointer<TreeItem> second) {
+
+  if (first->type() != second->type())
+      return first->type() > second->type();
+
+  return first->getDisplayName() < second->getDisplayName();
+}
+
+void AbstractNamespaceItem::appendNamespace(QSharedPointer<AbstractNamespaceItem> item) {
+    m_childNamespaces[item->getName()] = item;
+    m_childItems.append(item.staticCast<TreeItem>());
+
+    std::sort(m_childItems.begin(), m_childItems.end(), compareNamespaces);
+}
+
 uint AbstractNamespaceItem::childCount(bool recursive) const {
-  if (!recursive) {
-    if (m_rawChildKeys.size() > 0) {
-      return 0;
+    if (!recursive) {
+        if (m_rawChildKeys.size() > 0) {
+            return 0;
+        }
+
+        return m_childItems.size();
     }
 
-    return m_childItems.size();
-  }
-
-  if (m_rawChildKeys.size() > 0) {
+    if (m_rawChildKeys.size() > 0) {
     return m_rawChildKeys.size();
   }
 

--- a/src/modules/connections-tree/items/abstractnamespaceitem.h
+++ b/src/modules/connections-tree/items/abstractnamespaceitem.h
@@ -41,10 +41,7 @@ class AbstractNamespaceItem : public QObject, public TreeItem, public MemoryUsag
     m_rawChildKeys.append(k);
   }
 
-  virtual void appendNamespace(QSharedPointer<AbstractNamespaceItem> item) {
-    m_childNamespaces[item->getName()] = item;
-    m_childItems.append(item.staticCast<TreeItem>());
-  }
+  virtual void appendNamespace(QSharedPointer<AbstractNamespaceItem> item);
 
   virtual QSharedPointer<AbstractNamespaceItem> findChildNamespace(
       const QByteArray& name) {

--- a/src/modules/connections-tree/items/keyitem.h
+++ b/src/modules/connections-tree/items/keyitem.h
@@ -46,6 +46,7 @@ class KeyItem : public TreeItem, public MemoryUsage {
   QByteArray m_fullPath;
   QWeakPointer<TreeItem> m_parent;
   bool m_removed;
+  bool m_shortRendering;
 };
 
 }  // namespace ConnectionsTree

--- a/src/modules/connections-tree/items/namespaceitem.cpp
+++ b/src/modules/connections-tree/items/namespaceitem.cpp
@@ -32,8 +32,13 @@ QString NamespaceItem::getDisplayName() const {
 }
 
 QByteArray NamespaceItem::getName() const {
-  return m_fullPath.mid(
-      m_fullPath.lastIndexOf(m_operations->getNamespaceSeparator()) + 1);
+  qsizetype pos = m_fullPath.lastIndexOf(m_operations->getNamespaceSeparator());
+
+  if (pos >= 0) {
+      return m_fullPath.mid(pos + m_operations->getNamespaceSeparator().size());
+  } else {
+      return m_fullPath;
+  }
 }
 
 bool NamespaceItem::isEnabled() const { return m_removed == false; }

--- a/src/qml/GlobalSettings.qml
+++ b/src/qml/GlobalSettings.qml
@@ -180,14 +180,13 @@ Dialog {
                         }
 
                         BoolOption {
-                            id: keySorting
+                            id: namespacedKeysShortName
 
                             Layout.fillWidth: true
                             Layout.preferredHeight: 30
 
                             value: true
-                            label: qsTranslate("RDM","Enable key sorting in tree")
-                            description: qsTranslate("RDM","(Disable to improve treeview performance)")
+                            label: qsTranslate("RDM","Show only last part for namespaced keys")
                         }
 
                         IntOption {
@@ -296,8 +295,8 @@ Dialog {
         id: globalSettings
         category: "app"
 
-        property alias reopenNamespacesOnReload: nsReload.value
-        property alias enableKeySortingInTree: keySorting.value
+        property alias reopenNamespacesOnReload: nsReload.value        
+        property alias namespacedKeysShortName: namespacedKeysShortName.value
         property alias liveUpdateKeysLimit: liveKeyLimit.value
         property alias liveUpdateInterval: liveUpdateInterval.value
         property alias appFont: appFont.value

--- a/src/resources/translations/rdm.ts
+++ b/src/resources/translations/rdm.ts
@@ -143,7 +143,7 @@
 <context>
     <name>GlobalSettings</name>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="286"/>
+        <location filename="../../qml/GlobalSettings.qml" line="285"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -312,7 +312,7 @@
     </message>
     <message>
         <location filename="../../modules/connections-tree/items/databaseitem.cpp" line="247"/>
-        <location filename="../../modules/connections-tree/items/namespaceitem.cpp" line="136"/>
+        <location filename="../../modules/connections-tree/items/namespaceitem.cpp" line="141"/>
         <source>Key was added</source>
         <translation type="unfinished"></translation>
     </message>
@@ -414,7 +414,7 @@
     </message>
     <message>
         <location filename="../../qml/value-editor/ValueTabs.qml" line="304"/>
-        <location filename="../../modules/connections-tree/items/keyitem.cpp" line="130"/>
+        <location filename="../../modules/connections-tree/items/keyitem.cpp" line="146"/>
         <source>Do you really want to delete this key?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -858,10 +858,10 @@
     </message>
     <message>
         <location filename="../../qml/ConnectionSettignsDialog.qml" line="573"/>
-        <location filename="../../qml/GlobalSettings.qml" line="274"/>
+        <location filename="../../qml/GlobalSettings.qml" line="273"/>
         <location filename="../../qml/QuickStartDialog.qml" line="62"/>
         <location filename="../../qml/common/SaveToFileButton.qml" line="108"/>
-        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="606"/>
+        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="614"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -908,6 +908,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../qml/GlobalSettings.qml" line="189"/>
+        <source>Show only last part for namespaced keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../qml/GlobalSettings.qml" line="81"/>
         <source>Use system proxy settings</source>
         <translation type="unfinished"></translation>
@@ -934,42 +939,36 @@
     </message>
     <message>
         <location filename="../../qml/GlobalSettings.qml" line="179"/>
-        <location filename="../../qml/GlobalSettings.qml" line="190"/>
         <source>(Disable to improve treeview performance)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="189"/>
-        <source>Enable key sorting in tree</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../qml/GlobalSettings.qml" line="202"/>
+        <location filename="../../qml/GlobalSettings.qml" line="201"/>
         <source>Live update maximum allowed keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="214"/>
+        <location filename="../../qml/GlobalSettings.qml" line="213"/>
         <source>Live update interval (in seconds)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="222"/>
+        <location filename="../../qml/GlobalSettings.qml" line="221"/>
         <source>External Value View Formatters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="227"/>
+        <location filename="../../qml/GlobalSettings.qml" line="226"/>
         <source>Formatters path: %0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="243"/>
+        <location filename="../../qml/GlobalSettings.qml" line="242"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="248"/>
+        <location filename="../../qml/GlobalSettings.qml" line="247"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1167,7 +1166,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="258"/>
+        <location filename="../../qml/GlobalSettings.qml" line="257"/>
         <location filename="../../qml/console/RedisConsole.qml" line="209"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
@@ -1268,7 +1267,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="252"/>
+        <location filename="../../qml/GlobalSettings.qml" line="251"/>
         <location filename="../../qml/server-info/ServerInfoTabs.qml" line="424"/>
         <source>Command</source>
         <translation type="unfinished"></translation>
@@ -1396,12 +1395,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="602"/>
+        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="610"/>
         <source>Binary value is too large to display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="614"/>
+        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="622"/>
         <source>Save value to file: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1482,12 +1481,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../modules/connections-tree/items/abstractnamespaceitem.cpp" line="129"/>
+        <location filename="../../modules/connections-tree/items/abstractnamespaceitem.cpp" line="145"/>
         <source>Your redis-server doesn&apos;t support &lt;a href=&apos;https://redis.io/commands/memory-usage&apos;&gt;&lt;b&gt;MEMORY&lt;/b&gt;&lt;/a&gt; commands.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../modules/connections-tree/items/namespaceitem.cpp" line="131"/>
+        <location filename="../../modules/connections-tree/items/namespaceitem.cpp" line="136"/>
         <source>Key was added. Do you want to reload keys in selected namespace?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/resources/translations/rdm_es_ES.ts
+++ b/src/resources/translations/rdm_es_ES.ts
@@ -143,7 +143,7 @@
 <context>
     <name>GlobalSettings</name>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="286"/>
+        <location filename="../../qml/GlobalSettings.qml" line="285"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -352,7 +352,7 @@
     </message>
     <message>
         <location filename="../../modules/connections-tree/items/databaseitem.cpp" line="247"/>
-        <location filename="../../modules/connections-tree/items/namespaceitem.cpp" line="136"/>
+        <location filename="../../modules/connections-tree/items/namespaceitem.cpp" line="141"/>
         <source>Key was added</source>
         <translation>Clave añadida</translation>
     </message>
@@ -460,7 +460,7 @@
     </message>
     <message>
         <location filename="../../qml/value-editor/ValueTabs.qml" line="304"/>
-        <location filename="../../modules/connections-tree/items/keyitem.cpp" line="130"/>
+        <location filename="../../modules/connections-tree/items/keyitem.cpp" line="146"/>
         <source>Do you really want to delete this key?</source>
         <translation>¿Seguro que quieres borrar esta clave?</translation>
     </message>
@@ -985,10 +985,10 @@
     </message>
     <message>
         <location filename="../../qml/ConnectionSettignsDialog.qml" line="573"/>
-        <location filename="../../qml/GlobalSettings.qml" line="274"/>
+        <location filename="../../qml/GlobalSettings.qml" line="273"/>
         <location filename="../../qml/QuickStartDialog.qml" line="62"/>
         <location filename="../../qml/common/SaveToFileButton.qml" line="108"/>
-        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="606"/>
+        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="614"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -1073,27 +1073,30 @@
     </message>
     <message>
         <location filename="../../qml/GlobalSettings.qml" line="179"/>
-        <location filename="../../qml/GlobalSettings.qml" line="190"/>
         <source>(Disable to improve treeview performance)</source>
         <translation>Desactivar para mejorar el rendimiento de la vista de árbol</translation>
     </message>
     <message>
         <location filename="../../qml/GlobalSettings.qml" line="189"/>
-        <source>Enable key sorting in tree</source>
-        <translation>Activar ordenamiento de claves en el árbol</translation>
+        <source>Show only last part for namespaced keys</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="202"/>
+        <source>Enable key sorting in tree</source>
+        <translation type="vanished">Activar ordenamiento de claves en el árbol</translation>
+    </message>
+    <message>
+        <location filename="../../qml/GlobalSettings.qml" line="201"/>
         <source>Live update maximum allowed keys</source>
         <translation>Máximo de claves permitidas en actualización automática</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="214"/>
+        <location filename="../../qml/GlobalSettings.qml" line="213"/>
         <source>Live update interval (in seconds)</source>
         <translation>Intervalo de actualización automática (en segundos)</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="222"/>
+        <location filename="../../qml/GlobalSettings.qml" line="221"/>
         <source>External Value View Formatters</source>
         <translation>Formateadores Externos de Visor de Valores</translation>
     </message>
@@ -1102,17 +1105,17 @@
         <translation type="vanished">Formateadores personalizados de visor de valores</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="227"/>
+        <location filename="../../qml/GlobalSettings.qml" line="226"/>
         <source>Formatters path: %0</source>
         <translation>Ruta a formateadores: %0</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="243"/>
+        <location filename="../../qml/GlobalSettings.qml" line="242"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="248"/>
+        <location filename="../../qml/GlobalSettings.qml" line="247"/>
         <source>Version</source>
         <translation>Versión</translation>
     </message>
@@ -1391,7 +1394,7 @@
         <translation>Argumentos</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="258"/>
+        <location filename="../../qml/GlobalSettings.qml" line="257"/>
         <location filename="../../qml/console/RedisConsole.qml" line="209"/>
         <source>Description</source>
         <translation>Descripción</translation>
@@ -1501,7 +1504,7 @@
         <translation>Nombre de Canal</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="252"/>
+        <location filename="../../qml/GlobalSettings.qml" line="251"/>
         <location filename="../../qml/server-info/ServerInfoTabs.qml" line="424"/>
         <source>Command</source>
         <translation>Comando</translation>
@@ -1632,12 +1635,12 @@
         <translation>Guardar Cambios</translation>
     </message>
     <message>
-        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="602"/>
+        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="610"/>
         <source>Binary value is too large to display</source>
         <translation>El valor binario es demasiado grande para mostrarse</translation>
     </message>
     <message>
-        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="614"/>
+        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="622"/>
         <source>Save value to file: </source>
         <translation>Guardar valor a fichero:</translation>
     </message>
@@ -1730,12 +1733,12 @@
         <translation>No se puede asignar el TTL a la clave </translation>
     </message>
     <message>
-        <location filename="../../modules/connections-tree/items/abstractnamespaceitem.cpp" line="129"/>
+        <location filename="../../modules/connections-tree/items/abstractnamespaceitem.cpp" line="145"/>
         <source>Your redis-server doesn&apos;t support &lt;a href=&apos;https://redis.io/commands/memory-usage&apos;&gt;&lt;b&gt;MEMORY&lt;/b&gt;&lt;/a&gt; commands.</source>
         <translation>El servidor redis no soporta comandos &lt;a href=&apos;https://redis.io/commands/memory-usage&apos;&gt;&lt;b&gt;MEMORY&lt;/b&gt;&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location filename="../../modules/connections-tree/items/namespaceitem.cpp" line="131"/>
+        <location filename="../../modules/connections-tree/items/namespaceitem.cpp" line="136"/>
         <source>Key was added. Do you want to reload keys in selected namespace?</source>
         <translation>Clave añadida. ¿Quiere recargar las claves en el namespace seleccionado?</translation>
     </message>

--- a/src/resources/translations/rdm_ja_JP.ts
+++ b/src/resources/translations/rdm_ja_JP.ts
@@ -143,7 +143,7 @@
 <context>
     <name>GlobalSettings</name>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="286"/>
+        <location filename="../../qml/GlobalSettings.qml" line="285"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
@@ -316,7 +316,7 @@
     </message>
     <message>
         <location filename="../../modules/connections-tree/items/databaseitem.cpp" line="247"/>
-        <location filename="../../modules/connections-tree/items/namespaceitem.cpp" line="136"/>
+        <location filename="../../modules/connections-tree/items/namespaceitem.cpp" line="141"/>
         <source>Key was added</source>
         <translation>キーを追加しました。</translation>
     </message>
@@ -420,7 +420,7 @@
     </message>
     <message>
         <location filename="../../qml/value-editor/ValueTabs.qml" line="304"/>
-        <location filename="../../modules/connections-tree/items/keyitem.cpp" line="130"/>
+        <location filename="../../modules/connections-tree/items/keyitem.cpp" line="146"/>
         <source>Do you really want to delete this key?</source>
         <translation>このキーを本当に削除してもよろしいですか?</translation>
     </message>
@@ -890,10 +890,10 @@
     </message>
     <message>
         <location filename="../../qml/ConnectionSettignsDialog.qml" line="573"/>
-        <location filename="../../qml/GlobalSettings.qml" line="274"/>
+        <location filename="../../qml/GlobalSettings.qml" line="273"/>
         <location filename="../../qml/QuickStartDialog.qml" line="62"/>
         <location filename="../../qml/common/SaveToFileButton.qml" line="108"/>
-        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="606"/>
+        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="614"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -978,42 +978,45 @@
     </message>
     <message>
         <location filename="../../qml/GlobalSettings.qml" line="179"/>
-        <location filename="../../qml/GlobalSettings.qml" line="190"/>
         <source>(Disable to improve treeview performance)</source>
         <translation>(無効にするとツリービューが早くなります)</translation>
     </message>
     <message>
         <location filename="../../qml/GlobalSettings.qml" line="189"/>
-        <source>Enable key sorting in tree</source>
-        <translation>ツリーのキーをソートする</translation>
+        <source>Show only last part for namespaced keys</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="202"/>
+        <source>Enable key sorting in tree</source>
+        <translation type="vanished">ツリーのキーをソートする</translation>
+    </message>
+    <message>
+        <location filename="../../qml/GlobalSettings.qml" line="201"/>
         <source>Live update maximum allowed keys</source>
         <translation>ライブアップデートで読み込むキーの最大数</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="214"/>
+        <location filename="../../qml/GlobalSettings.qml" line="213"/>
         <source>Live update interval (in seconds)</source>
         <translation>ライブアップデートの更新頻度(秒)</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="222"/>
+        <location filename="../../qml/GlobalSettings.qml" line="221"/>
         <source>External Value View Formatters</source>
         <translation>外部の値ビューフォーマッタ</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="227"/>
+        <location filename="../../qml/GlobalSettings.qml" line="226"/>
         <source>Formatters path: %0</source>
         <translation>フォーマッタのパス: %0</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="243"/>
+        <location filename="../../qml/GlobalSettings.qml" line="242"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="248"/>
+        <location filename="../../qml/GlobalSettings.qml" line="247"/>
         <source>Version</source>
         <translation>バージョン</translation>
     </message>
@@ -1215,7 +1218,7 @@
         <translation>パラメーター</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="258"/>
+        <location filename="../../qml/GlobalSettings.qml" line="257"/>
         <location filename="../../qml/console/RedisConsole.qml" line="209"/>
         <source>Description</source>
         <translation>説明</translation>
@@ -1316,7 +1319,7 @@
         <translation>チャンネル名</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="252"/>
+        <location filename="../../qml/GlobalSettings.qml" line="251"/>
         <location filename="../../qml/server-info/ServerInfoTabs.qml" line="424"/>
         <source>Command</source>
         <translation>コマンド</translation>
@@ -1444,12 +1447,12 @@
         <translation>変更を保存</translation>
     </message>
     <message>
-        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="602"/>
+        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="610"/>
         <source>Binary value is too large to display</source>
         <translation>バイナリが大きすぎるため表示できません</translation>
     </message>
     <message>
-        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="614"/>
+        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="622"/>
         <source>Save value to file: </source>
         <translation>値をファイルに保存: </translation>
     </message>
@@ -1538,12 +1541,12 @@
         <translation>TTLをキーに設定できません</translation>
     </message>
     <message>
-        <location filename="../../modules/connections-tree/items/abstractnamespaceitem.cpp" line="129"/>
+        <location filename="../../modules/connections-tree/items/abstractnamespaceitem.cpp" line="145"/>
         <source>Your redis-server doesn&apos;t support &lt;a href=&apos;https://redis.io/commands/memory-usage&apos;&gt;&lt;b&gt;MEMORY&lt;/b&gt;&lt;/a&gt; commands.</source>
         <translation>あなたのRedisサーバは&lt;a href=&apos;https://redis.io/commands/memory-usage&apos;&gt;&lt;b&gt;MEMORY&lt;/b&gt;&lt;/a&gt;コマンドをサポートしていません。</translation>
     </message>
     <message>
-        <location filename="../../modules/connections-tree/items/namespaceitem.cpp" line="131"/>
+        <location filename="../../modules/connections-tree/items/namespaceitem.cpp" line="136"/>
         <source>Key was added. Do you want to reload keys in selected namespace?</source>
         <translation>キーを追加しました。選択されているネームスペースのキーをリロードしますか?</translation>
     </message>

--- a/src/resources/translations/rdm_ru_RU.ts
+++ b/src/resources/translations/rdm_ru_RU.ts
@@ -143,7 +143,7 @@
 <context>
     <name>GlobalSettings</name>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="286"/>
+        <location filename="../../qml/GlobalSettings.qml" line="285"/>
         <source>Cancel</source>
         <translation type="unfinished">Отмена</translation>
     </message>
@@ -332,7 +332,7 @@
     </message>
     <message>
         <location filename="../../modules/connections-tree/items/databaseitem.cpp" line="247"/>
-        <location filename="../../modules/connections-tree/items/namespaceitem.cpp" line="136"/>
+        <location filename="../../modules/connections-tree/items/namespaceitem.cpp" line="141"/>
         <source>Key was added</source>
         <translation>Ключ добавлен</translation>
     </message>
@@ -440,7 +440,7 @@
     </message>
     <message>
         <location filename="../../qml/value-editor/ValueTabs.qml" line="304"/>
-        <location filename="../../modules/connections-tree/items/keyitem.cpp" line="130"/>
+        <location filename="../../modules/connections-tree/items/keyitem.cpp" line="146"/>
         <source>Do you really want to delete this key?</source>
         <translation type="unfinished">Удалить ключ?</translation>
     </message>
@@ -946,10 +946,10 @@
     </message>
     <message>
         <location filename="../../qml/ConnectionSettignsDialog.qml" line="573"/>
-        <location filename="../../qml/GlobalSettings.qml" line="274"/>
+        <location filename="../../qml/GlobalSettings.qml" line="273"/>
         <location filename="../../qml/QuickStartDialog.qml" line="62"/>
         <location filename="../../qml/common/SaveToFileButton.qml" line="108"/>
-        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="606"/>
+        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="614"/>
         <source>OK</source>
         <translation type="unfinished">ОК</translation>
     </message>
@@ -1026,27 +1026,30 @@
     </message>
     <message>
         <location filename="../../qml/GlobalSettings.qml" line="179"/>
-        <location filename="../../qml/GlobalSettings.qml" line="190"/>
         <source>(Disable to improve treeview performance)</source>
         <translation>(Отключите для увеличения производительности)</translation>
     </message>
     <message>
         <location filename="../../qml/GlobalSettings.qml" line="189"/>
-        <source>Enable key sorting in tree</source>
-        <translation type="unfinished">Включить сортировку ключей в дереве</translation>
+        <source>Show only last part for namespaced keys</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="202"/>
+        <source>Enable key sorting in tree</source>
+        <translation type="obsolete">Включить сортировку ключей в дереве</translation>
+    </message>
+    <message>
+        <location filename="../../qml/GlobalSettings.qml" line="201"/>
         <source>Live update maximum allowed keys</source>
         <translation type="unfinished">Обновление в реальном времени максимума разрешенных ключей</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="214"/>
+        <location filename="../../qml/GlobalSettings.qml" line="213"/>
         <source>Live update interval (in seconds)</source>
         <translation type="unfinished">Интервал обновления (в секундах)</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="222"/>
+        <location filename="../../qml/GlobalSettings.qml" line="221"/>
         <source>External Value View Formatters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1055,17 +1058,17 @@
         <translation type="obsolete">Пользовательские значения форматирования вывода</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="227"/>
+        <location filename="../../qml/GlobalSettings.qml" line="226"/>
         <source>Formatters path: %0</source>
         <translation type="unfinished">Путь к форматированию: %0</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="243"/>
+        <location filename="../../qml/GlobalSettings.qml" line="242"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="248"/>
+        <location filename="../../qml/GlobalSettings.qml" line="247"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1327,7 +1330,7 @@
         <translation type="unfinished">Параметры</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="258"/>
+        <location filename="../../qml/GlobalSettings.qml" line="257"/>
         <location filename="../../qml/console/RedisConsole.qml" line="209"/>
         <source>Description</source>
         <translation type="unfinished">Описание</translation>
@@ -1428,7 +1431,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="252"/>
+        <location filename="../../qml/GlobalSettings.qml" line="251"/>
         <location filename="../../qml/server-info/ServerInfoTabs.qml" line="424"/>
         <source>Command</source>
         <translation type="unfinished"></translation>
@@ -1560,12 +1563,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="602"/>
+        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="610"/>
         <source>Binary value is too large to display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="614"/>
+        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="622"/>
         <source>Save value to file: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1646,12 +1649,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../modules/connections-tree/items/abstractnamespaceitem.cpp" line="129"/>
+        <location filename="../../modules/connections-tree/items/abstractnamespaceitem.cpp" line="145"/>
         <source>Your redis-server doesn&apos;t support &lt;a href=&apos;https://redis.io/commands/memory-usage&apos;&gt;&lt;b&gt;MEMORY&lt;/b&gt;&lt;/a&gt; commands.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../modules/connections-tree/items/namespaceitem.cpp" line="131"/>
+        <location filename="../../modules/connections-tree/items/namespaceitem.cpp" line="136"/>
         <source>Key was added. Do you want to reload keys in selected namespace?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/resources/translations/rdm_zh_CN.ts
+++ b/src/resources/translations/rdm_zh_CN.ts
@@ -143,7 +143,7 @@
 <context>
     <name>GlobalSettings</name>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="286"/>
+        <location filename="../../qml/GlobalSettings.qml" line="285"/>
         <source>Cancel</source>
         <translation type="unfinished">取消</translation>
     </message>
@@ -352,7 +352,7 @@
     </message>
     <message>
         <location filename="../../modules/connections-tree/items/databaseitem.cpp" line="247"/>
-        <location filename="../../modules/connections-tree/items/namespaceitem.cpp" line="136"/>
+        <location filename="../../modules/connections-tree/items/namespaceitem.cpp" line="141"/>
         <source>Key was added</source>
         <translation>键已经插入</translation>
     </message>
@@ -460,7 +460,7 @@
     </message>
     <message>
         <location filename="../../qml/value-editor/ValueTabs.qml" line="304"/>
-        <location filename="../../modules/connections-tree/items/keyitem.cpp" line="130"/>
+        <location filename="../../modules/connections-tree/items/keyitem.cpp" line="146"/>
         <source>Do you really want to delete this key?</source>
         <translation>确定要删除该键？</translation>
     </message>
@@ -987,10 +987,10 @@
     </message>
     <message>
         <location filename="../../qml/ConnectionSettignsDialog.qml" line="573"/>
-        <location filename="../../qml/GlobalSettings.qml" line="274"/>
+        <location filename="../../qml/GlobalSettings.qml" line="273"/>
         <location filename="../../qml/QuickStartDialog.qml" line="62"/>
         <location filename="../../qml/common/SaveToFileButton.qml" line="108"/>
-        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="606"/>
+        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="614"/>
         <source>OK</source>
         <translation>确定</translation>
     </message>
@@ -1079,27 +1079,30 @@
     </message>
     <message>
         <location filename="../../qml/GlobalSettings.qml" line="179"/>
-        <location filename="../../qml/GlobalSettings.qml" line="190"/>
         <source>(Disable to improve treeview performance)</source>
         <translation>(禁用树状视图提高性能)</translation>
     </message>
     <message>
         <location filename="../../qml/GlobalSettings.qml" line="189"/>
-        <source>Enable key sorting in tree</source>
-        <translation>打开树状视图键名排序功能</translation>
+        <source>Show only last part for namespaced keys</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="202"/>
+        <source>Enable key sorting in tree</source>
+        <translation type="vanished">打开树状视图键名排序功能</translation>
+    </message>
+    <message>
+        <location filename="../../qml/GlobalSettings.qml" line="201"/>
         <source>Live update maximum allowed keys</source>
         <translation>实时更新最大允许键数量</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="214"/>
+        <location filename="../../qml/GlobalSettings.qml" line="213"/>
         <source>Live update interval (in seconds)</source>
         <translation>实时更新间隔 (秒)</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="222"/>
+        <location filename="../../qml/GlobalSettings.qml" line="221"/>
         <source>External Value View Formatters</source>
         <translation type="unfinished">外部键值格式化配置</translation>
     </message>
@@ -1108,17 +1111,17 @@
         <translation type="vanished">自定义键值格式化配置</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="227"/>
+        <location filename="../../qml/GlobalSettings.qml" line="226"/>
         <source>Formatters path: %0</source>
         <translation>格式化配置路径：%0</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="243"/>
+        <location filename="../../qml/GlobalSettings.qml" line="242"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="248"/>
+        <location filename="../../qml/GlobalSettings.qml" line="247"/>
         <source>Version</source>
         <translation>版本</translation>
     </message>
@@ -1397,7 +1400,7 @@
         <translation>参数</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="258"/>
+        <location filename="../../qml/GlobalSettings.qml" line="257"/>
         <location filename="../../qml/console/RedisConsole.qml" line="209"/>
         <source>Description</source>
         <translation>描述</translation>
@@ -1498,7 +1501,7 @@
         <translation type="unfinished">通道名</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="252"/>
+        <location filename="../../qml/GlobalSettings.qml" line="251"/>
         <location filename="../../qml/server-info/ServerInfoTabs.qml" line="424"/>
         <source>Command</source>
         <translation>指令</translation>
@@ -1630,12 +1633,12 @@
         <translation type="unfinished">保存更改</translation>
     </message>
     <message>
-        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="602"/>
+        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="610"/>
         <source>Binary value is too large to display</source>
         <translation type="unfinished">二进制内容太长无法展示</translation>
     </message>
     <message>
-        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="614"/>
+        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="622"/>
         <source>Save value to file: </source>
         <translation type="unfinished">保存内容到文件：</translation>
     </message>
@@ -1728,12 +1731,12 @@
         <translation type="unfinished">无法给该键设置TTL</translation>
     </message>
     <message>
-        <location filename="../../modules/connections-tree/items/abstractnamespaceitem.cpp" line="129"/>
+        <location filename="../../modules/connections-tree/items/abstractnamespaceitem.cpp" line="145"/>
         <source>Your redis-server doesn&apos;t support &lt;a href=&apos;https://redis.io/commands/memory-usage&apos;&gt;&lt;b&gt;MEMORY&lt;/b&gt;&lt;/a&gt; commands.</source>
         <translation type="unfinished">你的Redis服务端不支持 &lt;a href=&apos;https://redis.io/commands/memory-usage&apos;&gt;&lt;b&gt;MEMORY&lt;/b&gt;&lt;/a&gt; 指令</translation>
     </message>
     <message>
-        <location filename="../../modules/connections-tree/items/namespaceitem.cpp" line="131"/>
+        <location filename="../../modules/connections-tree/items/namespaceitem.cpp" line="136"/>
         <source>Key was added. Do you want to reload keys in selected namespace?</source>
         <translation type="unfinished">键已经添加。需要重新加载选中的命名空间中的键吗？</translation>
     </message>

--- a/src/resources/translations/rdm_zh_TW.ts
+++ b/src/resources/translations/rdm_zh_TW.ts
@@ -143,7 +143,7 @@
 <context>
     <name>GlobalSettings</name>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="286"/>
+        <location filename="../../qml/GlobalSettings.qml" line="285"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
@@ -352,7 +352,7 @@
     </message>
     <message>
         <location filename="../../modules/connections-tree/items/databaseitem.cpp" line="247"/>
-        <location filename="../../modules/connections-tree/items/namespaceitem.cpp" line="136"/>
+        <location filename="../../modules/connections-tree/items/namespaceitem.cpp" line="141"/>
         <source>Key was added</source>
         <translation>已經插入鍵</translation>
     </message>
@@ -460,7 +460,7 @@
     </message>
     <message>
         <location filename="../../qml/value-editor/ValueTabs.qml" line="304"/>
-        <location filename="../../modules/connections-tree/items/keyitem.cpp" line="130"/>
+        <location filename="../../modules/connections-tree/items/keyitem.cpp" line="146"/>
         <source>Do you really want to delete this key?</source>
         <translation>確定要刪除該鍵？</translation>
     </message>
@@ -989,10 +989,10 @@
     </message>
     <message>
         <location filename="../../qml/ConnectionSettignsDialog.qml" line="573"/>
-        <location filename="../../qml/GlobalSettings.qml" line="274"/>
+        <location filename="../../qml/GlobalSettings.qml" line="273"/>
         <location filename="../../qml/QuickStartDialog.qml" line="62"/>
         <location filename="../../qml/common/SaveToFileButton.qml" line="108"/>
-        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="606"/>
+        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="614"/>
         <source>OK</source>
         <translation>確定</translation>
     </message>
@@ -1081,27 +1081,30 @@
     </message>
     <message>
         <location filename="../../qml/GlobalSettings.qml" line="179"/>
-        <location filename="../../qml/GlobalSettings.qml" line="190"/>
         <source>(Disable to improve treeview performance)</source>
         <translation>(停用樹狀檢視以提高性能)</translation>
     </message>
     <message>
         <location filename="../../qml/GlobalSettings.qml" line="189"/>
-        <source>Enable key sorting in tree</source>
-        <translation>打開樹狀檢視鍵名排序功能</translation>
+        <source>Show only last part for namespaced keys</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="202"/>
+        <source>Enable key sorting in tree</source>
+        <translation type="vanished">打開樹狀檢視鍵名排序功能</translation>
+    </message>
+    <message>
+        <location filename="../../qml/GlobalSettings.qml" line="201"/>
         <source>Live update maximum allowed keys</source>
         <translation>同步更新最大允許鍵數量</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="214"/>
+        <location filename="../../qml/GlobalSettings.qml" line="213"/>
         <source>Live update interval (in seconds)</source>
         <translation>同步更新時間 (秒)</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="222"/>
+        <location filename="../../qml/GlobalSettings.qml" line="221"/>
         <source>External Value View Formatters</source>
         <translation>外部的值格式化工具</translation>
     </message>
@@ -1110,17 +1113,17 @@
         <translation type="vanished">自訂的值格式化工具</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="227"/>
+        <location filename="../../qml/GlobalSettings.qml" line="226"/>
         <source>Formatters path: %0</source>
         <translation>格式化工具路徑: %0</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="243"/>
+        <location filename="../../qml/GlobalSettings.qml" line="242"/>
         <source>Name</source>
         <translation>名稱</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="248"/>
+        <location filename="../../qml/GlobalSettings.qml" line="247"/>
         <source>Version</source>
         <translation>版本</translation>
     </message>
@@ -1399,7 +1402,7 @@
         <translation>參數</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="258"/>
+        <location filename="../../qml/GlobalSettings.qml" line="257"/>
         <location filename="../../qml/console/RedisConsole.qml" line="209"/>
         <source>Description</source>
         <translation>描述</translation>
@@ -1500,7 +1503,7 @@
         <translation>頻道名稱</translation>
     </message>
     <message>
-        <location filename="../../qml/GlobalSettings.qml" line="252"/>
+        <location filename="../../qml/GlobalSettings.qml" line="251"/>
         <location filename="../../qml/server-info/ServerInfoTabs.qml" line="424"/>
         <source>Command</source>
         <translation>指令</translation>
@@ -1632,12 +1635,12 @@
         <translation>儲存變更</translation>
     </message>
     <message>
-        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="602"/>
+        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="610"/>
         <source>Binary value is too large to display</source>
         <translation>二進位制內容過長而無法顯示</translation>
     </message>
     <message>
-        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="614"/>
+        <location filename="../../qml/value-editor/editors/MultilineEditor.qml" line="622"/>
         <source>Save value to file: </source>
         <translation>儲存值到檔案: </translation>
     </message>
@@ -1730,12 +1733,12 @@
         <translation>無法設定 TTL 給鍵 </translation>
     </message>
     <message>
-        <location filename="../../modules/connections-tree/items/abstractnamespaceitem.cpp" line="129"/>
+        <location filename="../../modules/connections-tree/items/abstractnamespaceitem.cpp" line="145"/>
         <source>Your redis-server doesn&apos;t support &lt;a href=&apos;https://redis.io/commands/memory-usage&apos;&gt;&lt;b&gt;MEMORY&lt;/b&gt;&lt;/a&gt; commands.</source>
         <translation>你的 Redis 伺服器不支援 &lt;a href=&apos;https://redis.io/commands/memory-usage&apos;&gt;&lt;b&gt;MEMORY&lt;/b&gt;&lt;/a&gt; 指令。</translation>
     </message>
     <message>
-        <location filename="../../modules/connections-tree/items/namespaceitem.cpp" line="131"/>
+        <location filename="../../modules/connections-tree/items/namespaceitem.cpp" line="136"/>
         <source>Key was added. Do you want to reload keys in selected namespace?</source>
         <translation>已新增鍵。你想要重新載入命名空間中的鍵嗎？</translation>
     </message>


### PR DESCRIPTION
* Show only last part for namespaced keys
* Show namespaces first
* Remove ignored option from Global Settings
* Fix namespace rendering with multichar ns separators

Fix #4962