### PR TITLE
Add 'Keywords' to the 'rdm.desktop'

### DIFF
--- a/src/resources/rdm.desktop
+++ b/src/resources/rdm.desktop
@@ -8,3 +8,4 @@ Exec=/opt/redis-desktop-manager/rdm.sh
 Terminal=false
 StartupNotify=true
 Icon=rdm
+Keywords=RDM;Redis;


### PR DESCRIPTION
- Add `Keywords` to the `rdm.desktop` so that it can be found when we type `Redis` too.