### PR TITLE
Cleaning the unused modules from .gitmodules.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,6 @@
-[submodule "3rdparty/crashreporter"]
-	path = 3rdparty/crashreporter
-	url = https://github.com/RedisDesktop/CrashReporter.git
 [submodule "3rdparty/qredisclient"]
 	path = 3rdparty/qredisclient
 	url = https://github.com/uglide/qredisclient.git
-[submodule "3rdparty/gbreakpad"]
-	path = 3rdparty/gbreakpad
-	url = https://github.com/google/breakpad.git
-[submodule "3rdparty/qt-unix-signals"]
-	path = 3rdparty/qt-unix-signals
-	url = https://github.com/sijk/qt-unix-signals.git
 [submodule "3rdparty/pyotherside"]
 	path = 3rdparty/pyotherside
 	url = https://github.com/uglide/pyotherside.git


### PR DESCRIPTION
This is needed to continue with #4178.

One of the problems that I encountered while trying to build the Flatpak, is that the `flatpak-builder`, when using a git repository that contains submodules, need to have a correct reference inside the project. To make sure that this was the problem, I updated the `.gitmodules` and the build could continue without errors.

If this is not a breaking change, this should be merged in order to continue with the Flatpak packaging (which I already did in my local system)