### PR TITLE
Fix connections.json path in documentation

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,4 +6,6 @@
 
 **macOS App Store** `$HOME/Library/Containers/com.redisdesktop.rdm/Data/Library/Preferences/rdm/`
 
-**Linux** `$HOME/.rdm/connections.json`
+**Linux flatpak** `$HOME/.rdm/connections.json`
+
+**Linux snap** `$HOME/snap/redis-desktop-manager/common/.rdm/connections.json`


### PR DESCRIPTION
I fixed the paths of the connections.json file in the FAQ.
They are different for flatpak and snap.